### PR TITLE
Better gzipping, please merge pull request into backup_plan

### DIFF
--- a/meerkat/description_producer.py
+++ b/meerkat/description_producer.py
@@ -306,7 +306,8 @@ def process_bucket(params):
 				with gzip.open(new_filename, 'rb') as gzipped_input:
 					unzipped_name = new_filename[:-3]
 					with open(unzipped_name, 'wb') as unzipped_input:
-						unzipped_input.write(gzipped_input.read())
+						for line in gzipped_input:
+							unzipped_input.write(line)
 						logging.warning("%s unzipped.", new_filename)
 
 				safely_remove_file(new_filename)


### PR DESCRIPTION
There could be a problem with using gzip.read() the way we did.  Specifically, it tries to load the entire file into a list, which is stored in the heap, and eventually grows too large.
By using the for loop, we avoid creating a list structure that could crash the heap.
