### PR TITLE
Remove batching from classification

### DIFF
--- a/meerkat/classification/lua_bridge.py
+++ b/meerkat/classification/lua_bridge.py
@@ -95,8 +95,9 @@ def get_CNN(model_name):
 
 	make_batch = lua.eval('''
 		function(trans)
-			batch = torch.Tensor(128, #alphabet, 123)
-			for k = 1, 128 do
+			transLen = table.getn(trans)
+			batch = torch.Tensor(transLen, #alphabet, 123)
+			for k = 1, transLen do
 				stringToTensor(trans[k], 123, batch:select(1, k))
 			end
 			return batch
@@ -116,11 +117,12 @@ def get_CNN(model_name):
 
 	process_batch = lua.eval('''
 		function(batch)
+			batchLen = batch:size(1)
 			batch = batch:transpose(2, 3):contiguous():type("torch.CudaTensor")
 			output = model:forward(batch)
 			max, decision = output:double():max(2)
 			labels = {}
-			for k = 1, 128 do
+			for k = 1, batchLen do
 				labels[k] = decision:select(1, k)[1]
 			end
 			return labels

--- a/meerkat/web_service/web_consumer.py
+++ b/meerkat/web_service/web_consumer.py
@@ -31,9 +31,6 @@ CARD_CNN = get_CNN("card")
 BANK_SUBTYPE_CNN = get_CNN("card_subtype")
 CARD_SUBTYPE_CNN = get_CNN("bank_subtype")
 
-def grouper(iterable):
-	return zip_longest(*[iter(iterable)]*128, fillvalue={"description":""})
-
 class Web_Consumer():
 	"""Acts as a web service client to process and enrich
 	transactions in real time"""
@@ -381,12 +378,9 @@ class Web_Consumer():
 	def __apply_merchant_CNN(self, data, transactions):
 		"""Apply the merchant CNN to transactions"""
 
-		batches = grouper(transactions)
 		classifier = BANK_CNN if (data["container"] == "bank") else CARD_CNN
-		processed = []
 
-		for i, batch in enumerate(batches):
-			processed += classifier(batch)
+		processed = classifier(transactions)
 
 		return processed[0:len(transactions)]
 
@@ -399,11 +393,7 @@ class Web_Consumer():
 		if len(transactions) == 0:
 			return transactions
 
-		batches = grouper(transactions)
-		processed = []
-
-		for i, batch in enumerate(batches):
-			processed += classifier(batch, label_key="subtype_CNN")
+		processed = classifier(transactions, label_key="subtype_CNN")
 
 		processed = processed[0:len(transactions)]
 


### PR DESCRIPTION
Removes batching from web_consumer.py and lua_bridge.py enabling smaller requests to be processed quickly
