### PR TITLE
add flag to show locale conflict

### DIFF
--- a/config/web_service.json
+++ b/config/web_service.json
@@ -22,5 +22,6 @@
         "index" : "factual_index",
         "type" : "factual_type"
     },
-    "should_search" : true
+    "should_search" : true,
+    "show_conflict" : true
 }

--- a/meerkat/web_service/web_consumer.py
+++ b/meerkat/web_service/web_consumer.py
@@ -309,6 +309,15 @@ class WebConsumer():
 
 			trans["category_labels"] = [fallback]
 
+	def __has_conflict(self, trans):
+		"""judge if search engine locale contradict with bloom locale"""
+
+		if trans["locale_bloom"] != None and trans["is_physical_merchant"] == True and (trans["city"] != trans["locale_bloom"][0] or trans["state"] != trans["locale_bloom"][1]):
+			return True
+
+		return False
+
+
 	def ensure_output_schema(self, transactions):
 		"""Clean output to proper schema"""
 
@@ -326,9 +335,14 @@ class WebConsumer():
 				
 
 			# Override Locale with Bloom Results
-			if trans["locale_bloom"] != None and trans["is_physical_merchant"] == True:
+			if trans["locale_bloom"] != None and trans["is_physical_merchant"] == True and ("show_conflict" not in self.params or not self.params["show_conflict"]):
 				trans["city"] = trans["locale_bloom"][0]
 				trans["state"] = trans["locale_bloom"][1]
+
+			# show conflict if search engine locale contradicts bloom locale
+			if self.__has_conflict(trans) and "show_conflict" in self.params and self.params["show_conflict"]:
+				trans["city"] += '[' + trans["locale_bloom"][0] + ']'
+				trans["state"] += '[' + trans["locale_bloom"][1] + ']'
 
 			if "CNN" in trans:
 				del trans["CNN"]


### PR DESCRIPTION
I added "show_conflict" flag in config/web_service.json, if it is false, I will let search engine locale override by bloom locale. If it is true, I will show the conflict like this:
city: New York[New York City]
state: NY[NY]

The flag's default value is false.
