### PR TITLE
Add a new web service unit test for issue 510 and issue 512

### DIFF
--- a/data/input/issue_510_and_512.json
+++ b/data/input/issue_510_and_512.json
@@ -1,0 +1,34 @@
+{
+  "cobrand_id" : 1234,
+  "user_id" : 2345,
+  "container" : "bank",
+  "user_city" : "Mountain View",
+  "user_state" : "CA",
+  "user_country" : "US",
+  "cobrand_region" : 1,
+  "services_list" : ["bank_merchant_cnn", "should_search"],
+  "debug" : true,
+  "transaction_list" : [
+  {
+    "amount":4.99,
+    "date":"2014-12-09",
+    "ledger_entry":"debit",
+    "description":"CHECKCARD  1208 APL* ITUNES.COM/BILL                        866-712-7753 CA 24692164342000869308530",
+    "transaction_id":1
+  },
+  {
+    "amount":50,
+    "date":"2014-12-22",
+    "ledger_entry":"debit",
+    "description":"USAA 529 ACH     CONTRIB    ***********2052~~08888~~~~78824~~0~~~~0065",
+    "transaction_id":2
+  },
+  {
+    "amount":62.17,
+    "date":"2014-12-16",
+    "ledger_entry":"debit",
+    "description":"Debit Card Purchase RENAISSANCE HOTELS F/B NEW YORK NY",
+    "transaction_id":3
+  }
+]
+}

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -97,7 +97,8 @@ class WebServiceTest(unittest.TestCase):
 		('./data/input/input.json'),
 		('./data/input/web_service_input.json'),
 		('./data/input/issue_512.json'),
-		('./data/input/issue_510.json')
+		('./data/input/issue_510.json'),
+		('./data/input/issue_510_and_512.json')
 	])
 	def test_web_service_representative(self, path):
 		"""Test starts meerkat, runs representative transactions, and stop meerkat"""


### PR DESCRIPTION
A new web_service unit test:
- Add 5 optional input fields ( issue 510 ): 
  "user_city" : "Mountain View",
  "user_state" : "CA",
  "user_country" : "US",
  "cobrand_region" : 1,
  "services_list" : ["bank_merchant_cnn", "should_search"]
- Add a debug flag in the input fields ( issue 512 ):
  "debug" : true
