### PR TITLE
Category fix

### DIFF
--- a/meerkat/web_service/web_consumer.py
+++ b/meerkat/web_service/web_consumer.py
@@ -303,7 +303,7 @@ class WebConsumer():
 			subtypecategory = trans.get("subtype_CNN", {}).get("category",\
 					trans.get("subtype_CNN", {}).get("label", ""))
 					
-			If subtypecategory =="Other Income"  or subtypecategory =="Other Expenses" or trans["txn_sub_type"]=="Refund"
+			if subtypecategory == "Other Income" or subtypecategory == "Other Expenses" or trans["txn_sub_type"] == "Refund":
 			
 				trans["search"] = {"category_labels" : trans.get("category_labels", [])}
 
@@ -324,7 +324,7 @@ class WebConsumer():
 				trans["CNN"] = trans.get("CNN", {}).get("label", "")
 
 				trans.pop("subtype_CNN", None)
-			Else
+			else:
 				trans["category_labels"] = [subtypecategory]	
 				trans["CNN"] = trans.get("CNN", {}).get("label", "")
 				trans.pop("subtype_CNN", None)


### PR DESCRIPTION
If it is a non spend transaction and we find the merchant  - we need to use subtype category - more than merchant category. So subtype value takes a preference for category testing.

Example: Walmart Payroll -- merchant is walmart, subtype will be direct deposit and category should be paychecks/Salary

without this change it would show up as General Merchandise when it finds walmart - regardless of transaction subtype.
