### PR TITLE
remove unnecessary sleep in test

### DIFF
--- a/tests/web_service/test_web_service.py
+++ b/tests/web_service/test_web_service.py
@@ -24,12 +24,11 @@ def get_trans_text(path):
 	transFile.close()
 	return transaction_text
 
-def classify_one(self, transaction, max_retries=20, sleep_interval=2):
+def classify_one(self, transaction, max_retries=30):
 	"""Send a single transaction to the web service for classification"""
 	count = 1
 	while count <= max_retries:
 		try:
-			sleep(sleep_interval)
 			r_post = requests.post(
 				"https://localhost/meerkat/v2.2",
 				data=transaction,
@@ -88,11 +87,11 @@ class WebServiceTest(unittest.TestCase):
 		# max_retries times
 		while count <= max_retries:
 			try:
-				sleep(sleep_interval)
 				status = check_status()
 				self.assertTrue(status == 200)
 				return
 			except ConnectionError:
+				sleep(sleep_interval)
 				count += 1
 		self.assertTrue(0 == 1, "Failed to connect to Meerkat service")
 		return


### PR DESCRIPTION
Since we have startup_helper, sleep in classify_one is unnecessary.
Also, a sleep, if at all, should take place after a try-connection fails.

This shorten current test time by 10+ seconds.
